### PR TITLE
Save object before calculate totals

### DIFF
--- a/plugins/woocommerce/changelog/fix-26543
+++ b/plugins/woocommerce/changelog/fix-26543
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Save an order created via the REST API to prevent overrides from 3rd party plugins or themes if they try to add fees to the order.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -768,6 +768,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			if ( $creating ) {
 				$object->set_created_via( 'rest-api' );
 				$object->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
+				$object->save();
 				$object->calculate_totals();
 			} else {
 				// If items have changed, recalculate order totals.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -205,6 +205,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 			if ( $creating ) {
 				$object->set_created_via( 'rest-api' );
 				$object->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
+				$object->save();
 				$object->calculate_totals();
 			} else {
 				// If items have changed, recalculate order totals.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Orders created via the REST API can be saved wrongly if a plugin or theme tries to add fees hooking into `woocommerce_new_order`, since the action runs before saving the posted data to the DB and overrides the fees sent via the API call.

Closes #26543.

### How to test the changes in this Pull Request:

1. Add the hook described in the [issue](https://github.com/woocommerce/woocommerce/issues/26543).
2. Create an order via the API using the posted data [here](https://github.com/woocommerce/woocommerce/issues/26543#issuecomment-714637984).
3. Open the order in the admin.
4. The order should display properly all the totals.

<!-- End testing instructions -->